### PR TITLE
Reduce memory

### DIFF
--- a/src/analyze.py
+++ b/src/analyze.py
@@ -54,8 +54,7 @@ def summarize_json():
             summary = az.summary(idata).reset_index(names='parameter')
 
             # report number of divergent transitions
-            divergent = idata["diverging"]
-            divergences = divergent.nonzero()[0].size
+            divergences = idata.sample_stats.diverging.to_numpy().sum()
             summary['divergences'] = divergences
 
             # add the p value to the summary, after selecting  method


### PR DESCRIPTION
This reduces the memory of the simulation by moving the model building out of the `main` function and into a small `sample_model` function.

I also fixed a bug in `src.analyze` regarding the number of divergent transitions. 